### PR TITLE
Correct hostname param default value instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ var target = appResolver.getUrl();
 - `options` (optional) - An object containing:
   - `dist` - The directory containing the app files to serve.  By default, the `dist` directory is used.
   - `port` - The port to listen on.  By default, port `3000` is used, which is the port that the LMS expects it on.
-  - `hostname` - The hostname (or IP) to listen on. By default, `localhost` is used.  You should not need to change this.
+  - `hostname` - The hostname (or IP) to listen on. By default, the hostname of the operating system is used.  You should not need to change this.
   - `configFile` - The name of the app config file.  By default, `appconfig.json` is used.  You should not need to change this.
 
 ## Contributing


### PR DESCRIPTION
In my experience `localhost` is often not the default hostname but rather the machine name is. Looking at the code it seems that when an argument isn't provided the value defaults to nodes os.hostname value: https://github.com/Brightspace/frau-local-appresolver/blob/57928f7c0311df33f20ac9a3520114ac3424b82a/lib/appresolver.js#L8

The node docs indicate that `os.hostname` "returns the hostname of the operating system as a string.": https://nodejs.org/api/os.html#os_os_hostname

Perhaps this has changed in more recent versions of node but it seems worthwhile to update the docs here to reflect this.