### PR TITLE
When getting hostname prefer FQDN

### DIFF
--- a/lib/appresolver.js
+++ b/lib/appresolver.js
@@ -2,15 +2,35 @@
 
 var corsProxy = require('superagent-d2l-cors-proxy'),
 	chalk = require('chalk'),
-	os = require('os');
+	os = require('os'),
+	dns = require('dns'),
+	deasync = require('deasync');
 
 function getHostname(opts) {
-	var hostname = opts.hostname || os.hostname();
+	var hostname = opts.hostname || getFQDN() || os.hostname();
+	console.log('hostname is ', hostname);
 	if (hostname.indexOf('.local', hostname.length - 6) !== -1) {
 		hostname = hostname.substr(0, hostname.length - 6);
 	}
 	return hostname;
 }
+
+var getFQDN = deasync(function(cb) {
+	var uqdn = os.hostname();
+	dns.lookup(uqdn, { hints: dns.ADDRCONFIG }, function(err, ip) {
+		if (err) {
+			return cb(err);
+		}
+
+		dns.lookupService(ip, 0, function(err, fqdn) {
+			if (err) {
+				return cb(err);
+			}
+
+			cb(null, fqdn);
+		});
+	});
+});
 
 function LocalAppRegistry(appClass, opts) {
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "cors": "^2.7.1",
+    "deasync": "^0.1.13",
     "express": "^4.13.3",
     "q": "^1.4.1",
     "serve-static": "^1.10.0",

--- a/test/appresolver.js
+++ b/test/appresolver.js
@@ -31,8 +31,11 @@ describe('appresolver', function() {
 		});
 
 		it('hostname', function() {
-			expect(appresolver(APP_CLASS)._opts.hostname)
-				.to.be.equal(require('os').hostname().replace('.local', ''));
+			var hostname = appresolver(APP_CLASS)._opts.hostname;
+			expect(hostname)
+				.to.have.string(require('os').hostname().replace('.local', ''));
+			expect(hostname)
+				.to.not.have.string('.local');
 		});
 
 		it('port', function() {


### PR DESCRIPTION
If running the appresolver on an openstack machine it needs to include the fully qualified domain name in the hostname in order for machines within the D2L network to resolve it.