### PR TITLE
Add baseRoute config to control whether we add /app/ to routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,24 +29,26 @@ frau-local-appresolver --appclass|-c urn:d2l:fra:class:some-app
 However additional options (described below) can be configured:
 
 ```javascript
-frau-local-appresolver --appclass|-c urn:d2l:fra:class:some-app 
-                       --configfile|-f appconfig.json 
-                       --hostname|-h acme.com 
-                       --port|-p 3000 
+frau-local-appresolver --appclass|-c urn:d2l:fra:class:some-app
+                       --configfile|-f appconfig.json
+                       --hostname|-h acme.com
+                       --port|-p 3000
                        --dist|-d dist
+                       --useAppRoute|-u true
 ```
 
 ```javascript
 "scripts": {
   "resolver": "frau-local-appresolver"
 },
-"config": { 
+"config": {
   "frauLocalAppResolver": {
     "appClass": "urn:d2l:fra:class:some-app",
     "configFile": "appconfig.json",
     "hostname": "acme.com",
     "port": "3000",
-    "dist": "dist"
+    "dist": "dist",
+    "useAppRoute": "true"
    }
 }
 ```
@@ -77,6 +79,7 @@ var target = appResolver.getUrl();
   - `port` - The port to listen on.  By default, port `3000` is used, which is the port that the LMS expects it on.
   - `hostname` - The hostname (or IP) to listen on. By default, the hostname of the operating system is used.  You should not need to change this.
   - `configFile` - The name of the app config file.  By default, `appconfig.json` is used.  You should not need to change this.
+  - `useAppRoute` - Determines whether or not to include `/app/` in urls.  By default, `true` is used.  Setting this to `false` will allow you to use tools such as `es-dev-server` where you want the endpoint hosted at `http://localhost:3000/index.html` instead of `http://localhost:3000/app/index.html`.
 
 ## Contributing
 Contributions are welcome, please submit a pull request!

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ frau-local-appresolver --appclass|-c urn:d2l:fra:class:some-app
                        --hostname|-h acme.com
                        --port|-p 3000
                        --dist|-d dist
-                       --useAppRoute|-u true
+                       --baseRoute|-u app/
 ```
 
 ```javascript
@@ -48,7 +48,7 @@ frau-local-appresolver --appclass|-c urn:d2l:fra:class:some-app
     "hostname": "acme.com",
     "port": "3000",
     "dist": "dist",
-    "useAppRoute": "true"
+    "baseRoute": "app/"
    }
 }
 ```
@@ -79,7 +79,7 @@ var target = appResolver.getUrl();
   - `port` - The port to listen on.  By default, port `3000` is used, which is the port that the LMS expects it on.
   - `hostname` - The hostname (or IP) to listen on. By default, the hostname of the operating system is used.  You should not need to change this.
   - `configFile` - The name of the app config file.  By default, `appconfig.json` is used.  You should not need to change this.
-  - `useAppRoute` - Determines whether or not to include `/app/` in urls.  By default, `true` is used.  Setting this to `false` will allow you to use tools such as `es-dev-server` where you want the endpoint hosted at `http://localhost:3000/index.html` instead of `http://localhost:3000/app/index.html`.
+  - `baseRoute` - Specifies the base route to be included in urls.  By default, `app/` is used.  Setting this to different values (e.g. `''`) will allow you to use tools such as `es-dev-server` where you want the endpoint hosted at `http://localhost:3000/index.html` instead of `http://localhost:3000/app/index.html`.
 
 ## Contributing
 Contributions are welcome, please submit a pull request!

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ frau-local-appresolver --appclass|-c urn:d2l:fra:class:some-app
                        --hostname|-h acme.com
                        --port|-p 3000
                        --dist|-d dist
-                       --baseRoute|-b app/
+                       --baseRoute|-b /app
 ```
 
 ```javascript
@@ -48,7 +48,7 @@ frau-local-appresolver --appclass|-c urn:d2l:fra:class:some-app
     "hostname": "acme.com",
     "port": "3000",
     "dist": "dist",
-    "baseRoute": "app/"
+    "baseRoute": "/app"
    }
 }
 ```
@@ -79,7 +79,7 @@ var target = appResolver.getUrl();
   - `port` - The port to listen on.  By default, port `3000` is used, which is the port that the LMS expects it on.
   - `hostname` - The hostname (or IP) to listen on. By default, the hostname of the operating system is used.  You should not need to change this.
   - `configFile` - The name of the app config file.  By default, `appconfig.json` is used.  You should not need to change this.
-  - `baseRoute` - Specifies the base route to be included in urls.  By default, `app/` is used.  Setting this to different values (e.g. `''`) will allow you to use tools such as `es-dev-server` where you want the endpoint hosted at `http://localhost:3000/index.html` instead of `http://localhost:3000/app/index.html`.
+  - `baseRoute` - Specifies the base route to be included in urls.  By default, `/app` is used.  Setting this to different values (e.g. `''`) will allow you to use tools such as `es-dev-server` where you want the endpoint hosted at `http://localhost:3000/index.html` instead of `http://localhost:3000/app/index.html`.
 
 ## Contributing
 Contributions are welcome, please submit a pull request!

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ frau-local-appresolver --appclass|-c urn:d2l:fra:class:some-app
                        --hostname|-h acme.com
                        --port|-p 3000
                        --dist|-d dist
-                       --baseRoute|-u app/
+                       --baseRoute|-b app/
 ```
 
 ```javascript

--- a/bin/appresolvercli
+++ b/bin/appresolvercli
@@ -4,14 +4,14 @@ var chalk = require('chalk'),
 	argv = require('yargs')
 	optionsProvider = require('../src/optionsProvider');
 
-argv = argv.usage('Usage: frau-local-appresolver --appclass|-c [--configfile|-f] [--hostname|-h] [--port|-p] [--dist|-d] [--useAppRoute|-u]')
+argv = argv.usage('Usage: frau-local-appresolver --appclass|-c [--configfile|-f] [--hostname|-h] [--port|-p] [--dist|-d] [--baseRoute|-b]')
 	.example('frau-local-appresolver -c urn:d2l:fra:class:some-app -f appconfig.json -h acme.com -p 3000 -d dist')
 	.alias('c', 'appclass')
 	.alias('f', 'configfile')
 	.alias('h', 'hostname')
 	.alias('p', 'port')
 	.alias('d', 'dist')
-	.alias('u', 'useAppRoute')
+	.alias('b', 'baseRoute')
 	.argv;
 
 var appResolver = require('../src/appresolver');

--- a/bin/appresolvercli
+++ b/bin/appresolvercli
@@ -4,13 +4,14 @@ var chalk = require('chalk'),
 	argv = require('yargs')
 	optionsProvider = require('../src/optionsProvider');
 
-argv = argv.usage('Usage: frau-local-appresolver --appclass|-c [--configfile|-f] [--hostname|-h] [--port|-p] [--dist|-d]')
+argv = argv.usage('Usage: frau-local-appresolver --appclass|-c [--configfile|-f] [--hostname|-h] [--port|-p] [--dist|-d] [--useAppRoute|-u]')
 	.example('frau-local-appresolver -c urn:d2l:fra:class:some-app -f appconfig.json -h acme.com -p 3000 -d dist')
 	.alias('c', 'appclass')
 	.alias('f', 'configfile')
 	.alias('h', 'hostname')
 	.alias('p', 'port')
 	.alias('d', 'dist')
+	.alias('u', 'useAppRoute')
 	.argv;
 
 var appResolver = require('../src/appresolver');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frau-local-appresolver",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A free-range-app utility for resolving locally hosted apps.",
   "main": "src/index.js",
   "bin": {

--- a/src/appresolver.js
+++ b/src/appresolver.js
@@ -42,7 +42,7 @@ function LocalAppRegistry(appClass, opts) {
 	opts.port = opts.port || 3000;
 	opts.dist = opts.dist || 'dist';
 	opts.configFile = opts.configFile || 'appconfig.json';
-	opts.baseRoute = opts.baseRoute || '/app/';
+	opts.baseRoute = opts.baseRoute !== undefined ? opts.baseRoute : '/app';
 
 	this._opts = opts;
 }
@@ -81,7 +81,7 @@ LocalAppRegistry.prototype.host = function() {
 };
 
 LocalAppRegistry.prototype.getUrl = function() {
-	return 'http://' + this._opts.hostname + ':' + this._opts.port + this._opts.baseRoute;
+	return 'http://' + this._opts.hostname + ':' + this._opts.port + this._opts.baseRoute + '/';
 };
 
 LocalAppRegistry.prototype.getConfigUrl = function() {

--- a/src/appresolver.js
+++ b/src/appresolver.js
@@ -42,7 +42,7 @@ function LocalAppRegistry(appClass, opts) {
 	opts.port = opts.port || 3000;
 	opts.dist = opts.dist || 'dist';
 	opts.configFile = opts.configFile || 'appconfig.json';
-	opts.useAppRoute = opts.useAppRoute || 'true';
+	opts.baseRoute = opts.baseRoute || '/app/';
 
 	this._opts = opts;
 }
@@ -56,7 +56,7 @@ LocalAppRegistry.prototype.host = function() {
 
 	app.use(cors());
 
-	app.use('/app', serveStatic(self._opts.dist));
+	app.use(this._opts.baseRoute, serveStatic(self._opts.dist));
 
 	var encodedAppClass = encodeURIComponent(self._opts.appClass);
 	app.get('/resolve/' + encodedAppClass, function(req, res) {
@@ -81,8 +81,7 @@ LocalAppRegistry.prototype.host = function() {
 };
 
 LocalAppRegistry.prototype.getUrl = function() {
-	const appRoute = this._opts.useAppRoute.toLowerCase() === 'true' ? '/app/' : '/';
-	return 'http://' + this._opts.hostname + ':' + this._opts.port + appRoute;
+	return 'http://' + this._opts.hostname + ':' + this._opts.port + this._opts.baseRoute;
 };
 
 LocalAppRegistry.prototype.getConfigUrl = function() {

--- a/src/appresolver.js
+++ b/src/appresolver.js
@@ -42,6 +42,7 @@ function LocalAppRegistry(appClass, opts) {
 	opts.port = opts.port || 3000;
 	opts.dist = opts.dist || 'dist';
 	opts.configFile = opts.configFile || 'appconfig.json';
+	opts.useAppRoute = opts.useAppRoute || 'true';
 
 	this._opts = opts;
 }
@@ -80,7 +81,8 @@ LocalAppRegistry.prototype.host = function() {
 };
 
 LocalAppRegistry.prototype.getUrl = function() {
-	return 'http://' + this._opts.hostname + ':' + this._opts.port + '/app/';
+	const appRoute = this._opts.useAppRoute.toLowerCase() === 'true' ? '/app/' : '/';
+	return 'http://' + this._opts.hostname + ':' + this._opts.port + appRoute;
 };
 
 LocalAppRegistry.prototype.getConfigUrl = function() {

--- a/src/optionsProvider.js
+++ b/src/optionsProvider.js
@@ -21,9 +21,9 @@ module.exports = {
 		return argv.port ||
 			process.env.npm_package_config_frauLocalAppResolver_port;
 	},
-	getUseAppRoute: function(argv) {
-		return argv.useAppRoute ||
-			process.env.npm_package_config_frauLocalAppResolver_useAppRoute;
+	getBaseRoute: function(argv) {
+		return argv.baseRoute ||
+			process.env.npm_package_config_frauLocalAppResolver_baseRoute;
 	},
 	getOptions: function(argv) {
 		return {
@@ -32,7 +32,7 @@ module.exports = {
 			dist: this.getDist(argv),
 			hostname: this.getHostname(argv),
 			port: this.getPort(argv),
-			useAppRoute: this.getUseAppRoute(argv)
+			baseRoute: this.getBaseRoute(argv)
 		};
 	}
 };

--- a/src/optionsProvider.js
+++ b/src/optionsProvider.js
@@ -21,13 +21,18 @@ module.exports = {
 		return argv.port ||
 			process.env.npm_package_config_frauLocalAppResolver_port;
 	},
+	getUseAppRoute: function(argv) {
+		return argv.useAppRoute ||
+			process.env.npm_package_config_frauLocalAppResolver_useAppRoute;
+	},
 	getOptions: function(argv) {
 		return {
 			appClass: this.getAppClass(argv),
 			configFile: this.getConfigFile(argv),
 			dist: this.getDist(argv),
 			hostname: this.getHostname(argv),
-			port: this.getPort(argv)
+			port: this.getPort(argv),
+			useAppRoute: this.getUseAppRoute(argv)
 		};
 	}
 };

--- a/test/appresolver.js
+++ b/test/appresolver.js
@@ -53,6 +53,11 @@ describe('appresolver', function() {
 				.to.be.equal('appconfig.json');
 		});
 
+		it('useAppRoute', function() {
+			expect(appresolver(APP_CLASS)._opts.useAppRoute)
+				.to.be.equal('true');
+		});
+
 	});
 
 	describe('hostname', function() {
@@ -60,6 +65,11 @@ describe('appresolver', function() {
 		it('should strip ".local" domain from OSX hostname', function() {
 			expect(appresolver(APP_CLASS, { hostname: 'somehost.local' }).getUrl())
 				.to.be.equal('http://somehost:' + DEFAULT_PORT + '/app/');
+		});
+
+		it('should strip ".local" domain from OSX hostname - without app/', function() {
+			expect(appresolver(APP_CLASS, { hostname: 'somehost.local', useAppRoute: 'false' }).getUrl())
+				.to.be.equal('http://somehost:' + DEFAULT_PORT + '/');
 		});
 
 	});
@@ -71,6 +81,11 @@ describe('appresolver', function() {
 				.to.be.equal('http://somehost.com:11111/app/');
 		});
 
+		it('should return expected url - without app/', function() {
+			expect(appresolver(APP_CLASS, { hostname: 'somehost.com', port: 11111, useAppRoute: 'false' }).getUrl())
+				.to.be.equal('http://somehost.com:11111/');
+		});
+
 	});
 
 	describe('getConfigUrl', function() {
@@ -78,6 +93,11 @@ describe('appresolver', function() {
 		it('should return expected url', function() {
 			expect(appresolver(APP_CLASS, { hostname: 'somehost.com', port: 11111, configFile: 'someconf.js' }).getConfigUrl())
 				.to.be.equal('http://somehost.com:11111/app/someconf.js');
+		});
+
+		it('should return expected url - without app/', function() {
+			expect(appresolver(APP_CLASS, { hostname: 'somehost.com', port: 11111, configFile: 'someconf.js', useAppRoute: 'false' }).getConfigUrl())
+				.to.be.equal('http://somehost.com:11111/someconf.js');
 		});
 
 	});

--- a/test/appresolver.js
+++ b/test/appresolver.js
@@ -30,14 +30,6 @@ describe('appresolver', function() {
 			}).to.throw(Error, 'appClass is a required argument for LocalAppResolver.');
 		});
 
-		it('hostname', function() {
-			var hostname = appresolver(APP_CLASS)._opts.hostname;
-			expect(hostname)
-				.to.have.string(require('os').hostname().replace('.local', ''));
-			expect(hostname)
-				.to.not.have.string('.local');
-		});
-
 		it('port', function() {
 			expect(appresolver(APP_CLASS)._opts.port)
 				.to.be.equal(DEFAULT_PORT);

--- a/test/appresolver.js
+++ b/test/appresolver.js
@@ -55,7 +55,7 @@ describe('appresolver', function() {
 
 		it('baseRoute', function() {
 			expect(appresolver(APP_CLASS)._opts.baseRoute)
-				.to.be.equal('/app/');
+				.to.be.equal('/app');
 		});
 
 	});

--- a/test/appresolver.js
+++ b/test/appresolver.js
@@ -53,9 +53,9 @@ describe('appresolver', function() {
 				.to.be.equal('appconfig.json');
 		});
 
-		it('useAppRoute', function() {
-			expect(appresolver(APP_CLASS)._opts.useAppRoute)
-				.to.be.equal('true');
+		it('baseRoute', function() {
+			expect(appresolver(APP_CLASS)._opts.baseRoute)
+				.to.be.equal('/app/');
 		});
 
 	});
@@ -67,8 +67,8 @@ describe('appresolver', function() {
 				.to.be.equal('http://somehost:' + DEFAULT_PORT + '/app/');
 		});
 
-		it('should strip ".local" domain from OSX hostname - without app/', function() {
-			expect(appresolver(APP_CLASS, { hostname: 'somehost.local', useAppRoute: 'false' }).getUrl())
+		it('should strip ".local" domain from OSX hostname - with baseRoute', function() {
+			expect(appresolver(APP_CLASS, { hostname: 'somehost.local', baseRoute: '/' }).getUrl())
 				.to.be.equal('http://somehost:' + DEFAULT_PORT + '/');
 		});
 
@@ -81,8 +81,8 @@ describe('appresolver', function() {
 				.to.be.equal('http://somehost.com:11111/app/');
 		});
 
-		it('should return expected url - without app/', function() {
-			expect(appresolver(APP_CLASS, { hostname: 'somehost.com', port: 11111, useAppRoute: 'false' }).getUrl())
+		it('should return expected url - with baseRoute', function() {
+			expect(appresolver(APP_CLASS, { hostname: 'somehost.com', port: 11111, baseRoute: '/' }).getUrl())
 				.to.be.equal('http://somehost.com:11111/');
 		});
 
@@ -95,8 +95,8 @@ describe('appresolver', function() {
 				.to.be.equal('http://somehost.com:11111/app/someconf.js');
 		});
 
-		it('should return expected url - without app/', function() {
-			expect(appresolver(APP_CLASS, { hostname: 'somehost.com', port: 11111, configFile: 'someconf.js', useAppRoute: 'false' }).getConfigUrl())
+		it('should return expected url - with baseRoute', function() {
+			expect(appresolver(APP_CLASS, { hostname: 'somehost.com', port: 11111, configFile: 'someconf.js', baseRoute: '/' }).getConfigUrl())
 				.to.be.equal('http://somehost.com:11111/someconf.js');
 		});
 

--- a/test/appresolver.js
+++ b/test/appresolver.js
@@ -68,7 +68,7 @@ describe('appresolver', function() {
 		});
 
 		it('should strip ".local" domain from OSX hostname - with baseRoute', function() {
-			expect(appresolver(APP_CLASS, { hostname: 'somehost.local', baseRoute: '/' }).getUrl())
+			expect(appresolver(APP_CLASS, { hostname: 'somehost.local', baseRoute: '' }).getUrl())
 				.to.be.equal('http://somehost:' + DEFAULT_PORT + '/');
 		});
 
@@ -82,7 +82,7 @@ describe('appresolver', function() {
 		});
 
 		it('should return expected url - with baseRoute', function() {
-			expect(appresolver(APP_CLASS, { hostname: 'somehost.com', port: 11111, baseRoute: '/' }).getUrl())
+			expect(appresolver(APP_CLASS, { hostname: 'somehost.com', port: 11111, baseRoute: '' }).getUrl())
 				.to.be.equal('http://somehost.com:11111/');
 		});
 
@@ -96,7 +96,7 @@ describe('appresolver', function() {
 		});
 
 		it('should return expected url - with baseRoute', function() {
-			expect(appresolver(APP_CLASS, { hostname: 'somehost.com', port: 11111, configFile: 'someconf.js', baseRoute: '/' }).getConfigUrl())
+			expect(appresolver(APP_CLASS, { hostname: 'somehost.com', port: 11111, configFile: 'someconf.js', baseRoute: '' }).getConfigUrl())
 				.to.be.equal('http://somehost.com:11111/someconf.js');
 		});
 


### PR DESCRIPTION
Adding this config allows us to control whether we add `/app/` to endpoint routes. This is useful for using tools such as `es-dev-server` where we want `index.html`  hosted at  `http://localhost:3000/index.html` instead of `http://localhost:3000/app/index.html`. Since `es-dev-server` hosts files without actually building anything it is important that `endpoint` in `appconfig.json` points to the proper location of `index.html`.

Specifically, `frau-appconfig-builder` looks for an environment variable to determine if it’s running in CI or locally. If it’s running locally then it calls into `frau-local-appresolver` to get the URL which appends `/app/`. To fix this I added a parameter to control whether we add it while defaulting it to `true` so it functions as expected with all existing setups.