### PR TITLE
add publishConfig.registry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "url": "https://github.com/Brightspace/frau-local-appresolver/issues"
   },
   "homepage": "https://github.com/Brightspace/frau-local-appresolver",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "dependencies": {
     "chalk": "^4",
     "cors": "^2",


### PR DESCRIPTION
Needed to publish to public NPM while reading packages from our proxy registry

HOD-4564